### PR TITLE
Fix project tag shortcode

### DIFF
--- a/jetpack-portfolio-extensions.php
+++ b/jetpack-portfolio-extensions.php
@@ -21,7 +21,7 @@ add_action('init', 'wd_jetpack_portfolio_extensions_init');
  */
 function wd_jpe_register_script() {
     wp_register_style( 'jetpack-portfolio-extensions', plugins_url('/jetpack-portfolio-extensions.css', __FILE__), false, '3.0', 'all');
-    wp_register_script( 'isotope', 'https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/3.0.5/isotope.pkgd.min.js', array( 'jquery' ), null, true );
+    wp_register_script( 'isotope', 'https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/3.0.6/isotope.pkgd.min.js', array( 'jquery' ), null, true );
     wp_register_script( 'jetpack-portfolio-extensions-isotope', plugin_dir_url( __FILE__ ) . 'jetpack-portfolio-extensions-isotope.js', array( 'isotope' ), 1.2, true );
 }
 add_action('init', 'wd_jpe_register_script');

--- a/jetpack-portfolio-extensions.php
+++ b/jetpack-portfolio-extensions.php
@@ -109,9 +109,9 @@ add_filter( 'the_content', 'wd_jpe_show_excerpt' );
  * Add a shortcode `the_project_tags` to display them
  */
 function wd_jpe_shortcode_list_project_tags() {
-	echo get_the_term_list($post->ID, 'jetpack-portfolio-tag', '<ul class="portfolio-tag-list"><li>', '</li><li>', '</li></ul>' );
+	return get_the_term_list($post->ID, 'jetpack-portfolio-tag', '<ul class="portfolio-tag-list"><li>', '</li><li>', '</li></ul>' );
 }
-add_shortcode( 'the_project_tags', 'wd_jpe_list_project_tags' );
+add_shortcode( 'the_project_tags', 'wd_jpe_shortcode_list_project_tags' );
 
 /**
  * Print a list of Jetpack Project Types


### PR DESCRIPTION
Project tags shortcode wasn't working on my wordpress, so I've found that the function name was mispelled.
Also, using `echo` instead of `return` was breaking the content flow, showing the tags on the top of the page (for my theme Astra).

BTW really thanks for the plugin 😃